### PR TITLE
Support Python3

### DIFF
--- a/reversionup.py
+++ b/reversionup.py
@@ -37,7 +37,10 @@ __NAME__ = "ReversionUp"
 import os
 import re
 import argparse
-import ConfigParser
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
 
 CWD = os.getcwd()
 reversionup_file = CWD + "/setup.cfg"
@@ -87,7 +90,7 @@ class Reversionup(object):
         return version
 
     def __init__(self, version=DEFAULT_VERSION, file=None):
-        self._config = ConfigParser.ConfigParser()
+        self._config = ConfigParser()
         self._config.add_section(self.section_name)
         self._config.set(self.section_name, "version", version)
         self._file = file

--- a/reversionup.py
+++ b/reversionup.py
@@ -29,7 +29,7 @@ Usage:
 """
 
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __author__ = "Mardix"
 __license__ = "MIT"
 __NAME__ = "ReversionUp"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [reversionup]
-version = 0.4.0
+version = 0.4.1
 


### PR DESCRIPTION
In Python3, the ConfigParser module has been renamed. This should work on Python 2 and Python 3. Also bumped Version Number to 0.4.1 as there are no changes for users.