### PR TITLE
New Option --dry-run - Bump Version to 0.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ MANIFEST
 .DS_Store
 
 docs/_build*
+.envrc
+.virtualenv

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reversionup 
 
-version: 0.4.x
+version: 0.5.x
 
 ---
 
@@ -79,6 +79,20 @@ Increment the major number and reset the minor and the patch number
 
  	> 1.0.0
 
+---
+
+**reversionup (-d|--dry-run)**
+
+Don't write the setup.cfg
+
+	reversionup 
+	0.8.0
+
+ 	reversionup -d -p
+	0.8.1
+
+	reversionup
+	0.8.0
 
 ---
 
@@ -186,4 +200,4 @@ Now on each commit it will increase the patch number.
 
 ---
 
-License: MIT - Copyright 2014-2016 Mardix
+License: MIT - Copyright 2014-2016 Mardix, 2018 Sumpfgottheit

--- a/reversionup.py
+++ b/reversionup.py
@@ -29,7 +29,7 @@ Usage:
 """
 
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 __author__ = "Mardix"
 __license__ = "MIT"
 __NAME__ = "ReversionUp"
@@ -186,6 +186,9 @@ def main():
         parser.add_argument("-e", "--edit",
                            help="Manually edit the version number to bump to [ie: reversionup  -e 1.2.4]",
                            action="store")
+        parser.add_argument("-d", "--dry-run",
+                           help="Don't write to setup.cfg.",
+                           action="store_true")
         arg = parser.parse_args()
 
         rvnup = Reversionup(file=reversionup_file)
@@ -198,7 +201,8 @@ def main():
             rvnup.inc_minor()
         elif arg.major:
             rvnup.inc_major()
-        rvnup.write()
+        if not arg.dry_run:
+            rvnup.write()
 
         print(rvnup.version)
 

--- a/reversionup.py
+++ b/reversionup.py
@@ -37,7 +37,10 @@ __NAME__ = "ReversionUp"
 import os
 import re
 import argparse
-import ConfigParser
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
 
 CWD = os.getcwd()
 reversionup_file = CWD + "/setup.cfg"
@@ -87,7 +90,7 @@ class Reversionup(object):
         return version
 
     def __init__(self, version=DEFAULT_VERSION, file=None):
-        self._config = ConfigParser.ConfigParser()
+        self._config = ConfigParser()
         self._config.add_section(self.section_name)
         self._config.set(self.section_name, "version", version)
         self._file = file

--- a/reversionup.py
+++ b/reversionup.py
@@ -29,7 +29,7 @@ Usage:
 """
 
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __author__ = "Mardix"
 __license__ = "MIT"
 __NAME__ = "ReversionUp"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [reversionup]
-version = 0.4.1
+version = 0.5.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [reversionup]
-version = 0.4.0
+version = 0.4.1
 

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],

--- a/test.py
+++ b/test.py
@@ -55,3 +55,4 @@ class TestSemver(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+


### PR DESCRIPTION
Option -d|--dry-run added Setup.cfg is only written, if -d is not set.
Minor version bump due to API changes.
Includes Patches from former pull request (0.4.1)